### PR TITLE
feat: skip packages from store.shopware.com

### DIFF
--- a/src/LintPackagesCommand.php
+++ b/src/LintPackagesCommand.php
@@ -25,6 +25,10 @@ class LintPackagesCommand extends Command
         $packages = [];
 
         foreach (glob('*/*') as $package) {
+            if (str_starts_with($package, 'store.shopware.com/')) {
+                continue;
+            }
+
             $packages[] = [false, $package, $client->request('GET', "https://repo.packagist.org/p2/{$package}.json")];
         }
 


### PR DESCRIPTION
Currently there is no clean way to check for packages in store.shopware.com so we better skip this.